### PR TITLE
Prepare release and initial krew index addition

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -36,3 +36,7 @@ jobs:
       with:
         name: release
         path: dist/*
+    - uses: rajatjindal/krew-release-bot@v0.0.46
+      # Skip release bot step on initial plugin release in favor of manual addition.
+      # TODO(timebertt): drop the condition after releasing v0.1.0
+      if: ${{ !startsWith(github.ref, 'refs/tags/v') && github.ref != 'refs/tags/v0.1.0' }}

--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -7,8 +7,8 @@ builds:
   - CGO_ENABLED=0
   goos:
   - linux
-  - windows
   - darwin
+  - windows
   goarch:
   - amd64
   - arm64
@@ -23,13 +23,7 @@ builds:
 archives:
 - format: tar.gz
   # this name template makes the OS and Arch compatible with the results of uname.
-  name_template: >-
-    {{ .ProjectName }}_
-    {{- title .Os }}_
-    {{- if eq .Arch "amd64" }}x86_64
-    {{- else if eq .Arch "386" }}i386
-    {{- else }}{{ .Arch }}{{ end }}
-    {{- if .Arm }}v{{ .Arm }}{{ end }}
+  name_template: "{{ .ProjectName }}_{{ .Version }}_{{ title.Os }}_{{ .Arch }}{{ if .Arm }}v{{ .Arm }}{{ end }}"
   # use zip for windows archives
   format_overrides:
   - goos: windows
@@ -39,4 +33,4 @@ changelog:
   use: github
 
 snapshot:
-  name_template: "v{{ incpatch .Version }}-dev"
+  name_template: "v{{ incminor .Version }}-dev-{{ .ShortCommit }}"

--- a/.krew.yaml
+++ b/.krew.yaml
@@ -1,0 +1,41 @@
+apiVersion: krew.googlecontainertools.github.com/v1alpha2
+kind: Plugin
+metadata:
+  name: history
+spec:
+  version: {{ .TagName }}
+  homepage: https://github.com/timebertt/kubectl-history
+  shortDescription: Time-travel through your cluster
+  description: |
+    Go back in time in the history of rollouts and answers common questions like "Why was my Deployment rolled?"
+  platforms:
+  - selector:
+      matchLabels:
+        os: linux
+        arch: amd64
+    {{addURIAndSha "https://github.com/timebertt/kubectl-history/releases/download/{{ .TagName }}/kubectl-history_{{ .TagName }}_linux_amd64.tar.gz" .TagName }}
+    bin: kubectl-history
+  - selector:
+      matchLabels:
+        os: linux
+        arch: arm64
+    {{addURIAndSha "https://github.com/timebertt/kubectl-history/releases/download/{{ .TagName }}/kubectl-history_{{ .TagName }}_linux_arm64.tar.gz" .TagName }}
+    bin: kubectl-history
+  - selector:
+      matchLabels:
+        os: darwin
+        arch: amd64
+    {{addURIAndSha "https://github.com/timebertt/kubectl-history/releases/download/{{ .TagName }}/kubectl-history_{{ .TagName }}_darwin_amd64.tar.gz" .TagName }}
+    bin: kubectl-history
+  - selector:
+      matchLabels:
+        os: darwin
+        arch: arm64
+    {{addURIAndSha "https://github.com/timebertt/kubectl-history/releases/download/{{ .TagName }}/kubectl-history_{{ .TagName }}_darwin_arm64.tar.gz" .TagName }}
+    bin: kubectl-history
+  - selector:
+      matchLabels:
+        os: windows
+        arch: amd64
+    {{addURIAndSha "https://github.com/timebertt/kubectl-history/releases/download/{{ .TagName }}/kubectl-history_{{ .TagName }}_windows_amd64.zip" .TagName }}
+    bin: kubectl-history.exe


### PR DESCRIPTION
Part of https://github.com/timebertt/kubectl-history/issues/16

This PR refines the goreleaser config and adds a krew release workflow.